### PR TITLE
release: v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-04-10
+
+### Fixed
+- **macOS Environment Setup Regression**: Removed unsupported `--system-certs` CLI arguments from `uv` environment setup and dependency installation paths while preserving system certificate usage through `UV_SYSTEM_CERTS=true` environment injection.
+- **Gemma 4 Local Model Detection / Training**: Improved local HuggingFace / ModelScope model scanning to recognize both standard hub-cache layouts and direct local model directories, and updated training selection to pass local model paths directly for scanned MLX models.
+- **Gemma 4 Ollama Export Compatibility**: Added a `gemma4` architecture fallback (`Gemma4ForConditionalGeneration`) when exporting fused models to Ollama.
+
+### Changed
+- **Online Model Lists**: Restored Qwen to the latest locally available `Qwen 3.5` series, added the Gemma 4 series, removed Phi, and refreshed HF / Ollama model links to match currently available local model sources.
+- **Training Environment Dependencies**: Upgraded environment setup to install `mlx-lm[train]>=0.31.2` so Gemma 4 training support is available in the app-managed Python environment.
+- **HF GLM Recommendations**: Updated the HuggingFace MLX GLM recommendations to current public GLM-5 quantized variants while keeping Ollama on non-cloud `glm-4.7-flash`.
+
 ## [0.5.2] - 2026-03-25
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Mcourtyard/m-courtyard.git"

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "courtyard"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "courtyard"
-version = "0.5.2"
+version = "0.5.3"
 description = "AI Model Training Assistant - From raw text to fine-tuned local models"
 authors = ["tuwenbo"]
 edition = "2021"

--- a/app/src-tauri/scripts/export_ollama.py
+++ b/app/src-tauri/scripts/export_ollama.py
@@ -194,6 +194,7 @@ def fuse_and_dequantize_direct(model_path, adapter_path, output_path):
             "mistral": "MistralForCausalLM",
             "gemma": "GemmaForCausalLM",
             "gemma2": "Gemma2ForCausalLM",
+            "gemma4": "Gemma4ForConditionalGeneration",
             "phi3": "Phi3ForCausalLM",
         }
         mt = config.get("model_type", "")

--- a/app/src-tauri/src/commands/environment.rs
+++ b/app/src-tauri/src/commands/environment.rs
@@ -102,7 +102,7 @@ pub async fn setup_environment(app: tauri::AppHandle) -> Result<(), String> {
     }));
 
     let venv_result = tokio::process::Command::new(&uv_path)
-        .args(["venv", &venv_dir.to_string_lossy(), "--python", "3.11", "--system-certs"])
+        .args(["venv", &venv_dir.to_string_lossy(), "--python", "3.11"])
         .envs(build_uv_env())
         .output()
         .await
@@ -121,9 +121,8 @@ pub async fn setup_environment(app: tauri::AppHandle) -> Result<(), String> {
     // Step 2: Install mlx-lm + document parsing deps (PyPDF2, python-docx)
     let pip_result = tokio::process::Command::new(&uv_path)
         .args([
-            "pip", "install", "mlx-lm", "PyPDF2", "python-docx",
+            "pip", "install", "mlx-lm[train]>=0.31.2", "PyPDF2", "python-docx",
             "--python", &executor.python_bin().to_string_lossy(),
-            "--system-certs",
         ])
         .envs(build_uv_env())
         .output()

--- a/app/src-tauri/src/commands/files.rs
+++ b/app/src-tauri/src/commands/files.rs
@@ -33,7 +33,6 @@ pub fn ensure_doc_deps() {
                 .args([
                     "pip", "install", "PyPDF2", "python-docx",
                     "--python", &executor.python_bin().to_string_lossy(),
-                    "--system-certs",
                 ])
                 .envs(build_uv_env())
                 .output()

--- a/app/src-tauri/src/commands/training.rs
+++ b/app/src-tauri/src/commands/training.rs
@@ -554,22 +554,39 @@ fn scan_hf_style_cache(cache_dir: &std::path::Path, source: &str, models: &mut V
 
     for entry in entries.filter_map(|e| e.ok()) {
         let dir_name = entry.file_name().to_string_lossy().to_string();
-        if !dir_name.starts_with("models--") { continue; }
         let model_dir = entry.path();
-        let snapshots = model_dir.join("snapshots");
-        if !snapshots.exists() { continue; }
 
-        let latest_snapshot = std::fs::read_dir(&snapshots)
-            .ok()
-            .and_then(|rd| {
-                rd.filter_map(|e| e.ok())
-                    .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-                    .max_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()))
-            });
+        let detected = if dir_name.starts_with("models--") {
+            let snapshots = model_dir.join("snapshots");
+            if !snapshots.exists() { None } else {
+                let latest_snapshot = std::fs::read_dir(&snapshots)
+                    .ok()
+                    .and_then(|rd| {
+                        rd.filter_map(|e| e.ok())
+                            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                            .max_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()))
+                    });
 
-        if let Some(snap) = latest_snapshot {
-            let snap_path = snap.path();
-            let has_model_files = std::fs::read_dir(&snap_path).ok()
+                latest_snapshot.and_then(|snap| {
+                    let snap_path = snap.path();
+                    let has_model_files = std::fs::read_dir(&snap_path).ok()
+                        .map(|rd| rd.filter_map(|e| e.ok())
+                            .any(|e| {
+                                let n = e.file_name().to_string_lossy().to_string();
+                                n.ends_with(".safetensors") || n == "config.json"
+                            }))
+                        .unwrap_or(false);
+
+                    if !has_model_files { return None; }
+
+                    let model_id = dir_name.trim_start_matches("models--").replace("--", "/");
+                    let blobs_dir = model_dir.join("blobs");
+                    let size_mb = dir_size_recursive(&blobs_dir);
+                    Some((model_id, snap_path, size_mb))
+                })
+            }
+        } else {
+            let has_direct_model_files = std::fs::read_dir(&model_dir).ok()
                 .map(|rd| rd.filter_map(|e| e.ok())
                     .any(|e| {
                         let n = e.file_name().to_string_lossy().to_string();
@@ -577,14 +594,14 @@ fn scan_hf_style_cache(cache_dir: &std::path::Path, source: &str, models: &mut V
                     }))
                 .unwrap_or(false);
 
-            if !has_model_files { continue; }
+            if !has_direct_model_files {
+                None
+            } else {
+                Some((dir_name.clone(), model_dir.clone(), dir_size_recursive(&model_dir)))
+            }
+        };
 
-            let model_id = dir_name.trim_start_matches("models--").replace("--", "/");
-
-            // Calculate size from blobs/ directory (actual files, not symlinks)
-            let blobs_dir = model_dir.join("blobs");
-            let size_mb = dir_size_recursive(&blobs_dir);
-
+        if let Some((model_id, model_path, size_mb)) = detected {
             let name_lower = model_id.to_lowercase();
             let is_mlx = name_lower.contains("mlx")
                 || name_lower.contains("4bit")
@@ -593,7 +610,7 @@ fn scan_hf_style_cache(cache_dir: &std::path::Path, source: &str, models: &mut V
 
             models.push(LocalModelInfo {
                 name: model_id,
-                path: snap_path.to_string_lossy().to_string(),
+                path: model_path.to_string_lossy().to_string(),
                 size_mb,
                 is_mlx,
                 source: source.to_string(),

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "M-Courtyard",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "com.courtyard.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/src/components/ModelSelector.tsx
+++ b/app/src/components/ModelSelector.tsx
@@ -87,6 +87,16 @@ const HF_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease([
     moreUrl: "https://huggingface.co/models?search=mlx-community%2FQwen3.5",
   },
   {
+    brand: "gemma",
+    labelKey: "onlineBrands.gemma",
+    versions: [
+      { id: "mlx-community/gemma-4-31b-it-4bit", label: "Gemma 4 31B IT · 4-bit", size: "~20GB", descKey: "topRated", releasedAt: "2026-04-03" },
+      { id: "mlx-community/gemma-4-26b-a4b-it-4bit", label: "Gemma 4 26B-A4B IT · 4-bit", size: "~18GB", descKey: "higherQuality", releasedAt: "2026-04-03" },
+      { id: "mlx-community/gemma-4-e4b-it-4bit", label: "Gemma 4 E4B IT · 4-bit", size: "~9.6GB", descKey: "balanced", releasedAt: "2026-04-03" },
+    ],
+    moreUrl: "https://huggingface.co/models?search=mlx-community%2Fgemma-4",
+  },
+  {
     brand: "deepseek",
     labelKey: "onlineBrands.deepseek",
     versions: [
@@ -101,10 +111,10 @@ const HF_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease([
     brand: "glm",
     labelKey: "onlineBrands.glm",
     versions: [
-      { id: "mlx-community/GLM-4.7-Flash-4bit", label: "GLM 4.7 Flash · 4-bit", size: "~19GB", descKey: "topRated", releasedAt: "2026-01-19" },
-      { id: "mlx-community/GLM-4.7-Flash-8bit", label: "GLM 4.7 Flash · 8-bit", size: "~32GB", descKey: "higherQuality", releasedAt: "2026-01-19" },
+      { id: "mlx-community/GLM-5-4bit", label: "GLM 5 · 4-bit", size: "744B params", descKey: "topRated", releasedAt: "2026-02-12" },
+      { id: "mlx-community/GLM-5-8bit-MXFP8", label: "GLM 5 · 8-bit MXFP8", size: "744B params", descKey: "higherQuality", releasedAt: "2026-02-12" },
     ],
-    moreUrl: "https://huggingface.co/models?search=mlx-community%2FGLM-4.7-Flash",
+    moreUrl: "https://huggingface.co/models?search=mlx-community%2FGLM-5",
   },
   {
     brand: "llama",
@@ -134,16 +144,6 @@ const HF_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease([
     ],
     moreUrl: "https://huggingface.co/models?search=mlx-community%2FMistral",
   },
-  {
-    brand: "phi",
-    labelKey: "onlineBrands.phi",
-    versions: [
-      { id: "mlx-community/Phi-3.5-mini-instruct-4bit", label: "Phi 3.5 Mini · 4-bit", size: "~2.6GB", descKey: "lightweight", releasedAt: "2024-08-20" },
-      { id: "mlx-community/Phi-3-medium-128k-instruct-4bit", label: "Phi 3 Medium 14B · 4-bit", size: "~7.8GB", descKey: "higherQuality", releasedAt: "2024-05-21" },
-      { id: "mlx-community/Phi-3-mini-4k-instruct-4bit", label: "Phi 3 Mini · 4-bit", size: "~2.2GB", descKey: "lightweight", releasedAt: "2024-04-23" },
-    ],
-    moreUrl: "https://huggingface.co/models?search=mlx-community%2FPhi-3",
-  },
 ]);
 
 const OLLAMA_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease([
@@ -156,6 +156,16 @@ const OLLAMA_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease(
       { id: "qwen3.5:122b", label: "Qwen 3.5 122B", size: "~81GB", descKey: "popularGeneral", releasedAt: "2026-02-25" },
     ],
     moreUrl: "https://ollama.com/library/qwen3.5",
+  },
+  {
+    brand: "gemma",
+    labelKey: "onlineBrands.gemma",
+    versions: [
+      { id: "gemma4:31b", label: "Gemma 4 31B", size: "~20GB", descKey: "topRated", releasedAt: "2026-04-03" },
+      { id: "gemma4:26b", label: "Gemma 4 26B", size: "~18GB", descKey: "higherQuality", releasedAt: "2026-04-03" },
+      { id: "gemma4:e4b", label: "Gemma 4 E4B", size: "~9.6GB", descKey: "balanced", releasedAt: "2026-04-03" },
+    ],
+    moreUrl: "https://ollama.com/library/gemma4",
   },
   {
     brand: "deepseek",
@@ -203,16 +213,6 @@ const OLLAMA_ONLINE_GROUPS: OnlineModelBrandGroup[] = sortOnlineGroupsByRelease(
       { id: "mistral:latest", label: "Mistral 7B", size: "~4.1GB", descKey: "popularGeneral", releasedAt: "2023-12-10" },
     ],
     moreUrl: "https://ollama.com/search?q=mistral",
-  },
-  {
-    brand: "phi",
-    labelKey: "onlineBrands.phi",
-    versions: [
-      { id: "phi4-reasoning:14b", label: "Phi-4 Reasoning 14B", size: "~9GB", descKey: "reasoning", releasedAt: "2025-05-01" },
-      { id: "phi4:14b", label: "Phi-4 14B", size: "~9GB", descKey: "higherQuality", releasedAt: "2024-12-01" },
-      { id: "phi4-mini:3.8b", label: "Phi-4 Mini 3.8B", size: "~2.4GB", descKey: "lightweight", releasedAt: "2024-12-01" },
-    ],
-    moreUrl: "https://ollama.com/search?q=phi",
   },
 ]);
 
@@ -535,6 +535,8 @@ export function ModelSelector({ mode, selectedModel, onSelect, disabled, project
       const adapter = adapters.find((a) => a.path === m.path);
       if (adapter && onSelectAdapter) onSelectAdapter(adapter);
       onSelect(m.path);
+    } else if (mode === "training" && (m.source === "huggingface" || m.source === "modelscope")) {
+      onSelect(m.path, true);
     } else {
       onSelect(m.name);  // No isLocalPath - scanned models are already validated
     }

--- a/app/src/i18n/locales/en/common.json
+++ b/app/src/i18n/locales/en/common.json
@@ -89,13 +89,13 @@
     "sourceModelscope": "ModelScope",
     "onlineBrands": {
       "qwen": "Qwen",
+      "gemma": "Gemma",
       "deepseek": "DeepSeek",
       "glm": "GLM",
       "llama": "Llama",
       "gptoss": "GPT-OSS",
       "kimi": "Kimi",
-      "mistral": "Mistral",
-      "phi": "Phi"
+      "mistral": "Mistral"
     },
     "modelscopeWarnInline": "Current source is ModelScope, which does not support MLX model auto-download. Go to",
     "settingsLink": "Settings",

--- a/app/src/i18n/locales/en/settings.json
+++ b/app/src/i18n/locales/en/settings.json
@@ -68,7 +68,7 @@
     "httpProxyPlaceholder": "e.g. http://proxy.corp.com:8080",
     "httpsProxy": "HTTPS Proxy",
     "httpsProxyPlaceholder": "e.g. http://proxy.corp.com:8080",
-    "sslCertFile": "SSL Certificate File (PEM)",
+    "sslCertFile": "SSL Certificate File",
     "sslCertFilePlaceholder": "Path to CA certificate bundle, e.g. /etc/ssl/certs/ca-certificates.crt",
     "sslCertDir": "SSL Certificate Directory",
     "sslCertDirPlaceholder": "Path to directory containing CA certificates",
@@ -77,7 +77,7 @@
     "save": "Save",
     "browseFile": "Browse",
     "shellEnvHint": "Tip: Proxy variables from your shell profile (~/.zshrc) are automatically inherited when not configured here.",
-    "systemCertsHint": "System certificate store is always enabled for uv commands (--system-certs)."
+    "systemCertsHint": "System certificate store is always enabled via the UV_SYSTEM_CERTS environment variable."
   },
   "about": {
     "title": "About",

--- a/app/src/i18n/locales/zh-CN/common.json
+++ b/app/src/i18n/locales/zh-CN/common.json
@@ -89,13 +89,13 @@
     "sourceModelscope": "ModelScope",
     "onlineBrands": {
       "qwen": "Qwen",
+      "gemma": "Gemma",
       "deepseek": "DeepSeek",
       "glm": "GLM",
       "llama": "Llama",
       "gptoss": "GPT-OSS",
       "kimi": "Kimi",
-      "mistral": "Mistral",
-      "phi": "Phi"
+      "mistral": "Mistral"
     },
     "modelscopeWarnInline": "当前下载源为 ModelScope，不支持以下 MLX 模型自动下载。请到",
     "settingsLink": "设置",

--- a/app/src/i18n/locales/zh-CN/settings.json
+++ b/app/src/i18n/locales/zh-CN/settings.json
@@ -77,7 +77,7 @@
     "save": "保存",
     "browseFile": "浏览",
     "shellEnvHint": "提示：未在此处配置时，会自动继承 shell 配置文件（~/.zshrc）中的代理变量。",
-    "systemCertsHint": "系统证书存储始终启用（uv --system-certs）。"
+    "systemCertsHint": "系统证书存储始终启用（通过 UV_SYSTEM_CERTS 环境变量注入）。"
   },
   "about": {
     "title": "关于",


### PR DESCRIPTION
## v0.5.3

### Fixed
- **macOS Environment Setup Regression**: Removed unsupported `--system-certs` CLI arguments from `uv` environment setup and dependency installation paths while preserving system certificate usage through `UV_SYSTEM_CERTS=true` environment injection.
- **Gemma 4 Local Model Detection / Training**: Improved local HuggingFace / ModelScope model scanning to recognize both standard hub-cache layouts and direct local model directories, and updated training selection to pass local model paths directly for scanned MLX models.
- **Gemma 4 Ollama Export Compatibility**: Added a `gemma4` architecture fallback (`Gemma4ForConditionalGeneration`) when exporting fused models to Ollama.

### Changed
- **Online Model Lists**: Restored Qwen to the latest locally available `Qwen 3.5` series, added the Gemma 4 series, removed Phi, and refreshed HF / Ollama model links to match currently available local model sources.
- **Training Environment Dependencies**: Upgraded environment setup to install `mlx-lm[train]>=0.31.2` so Gemma 4 training support is available in the app-managed Python environment.
- **HF GLM Recommendations**: Updated the HuggingFace MLX GLM recommendations to current public GLM-5 quantized variants while keeping Ollama on non-cloud `glm-4.7-flash`.